### PR TITLE
Bug fix: doi is not insensitive in enrich process

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ezunpaywall is an API and database that queries the Unpaywall database containin
 **Table of content**
 - [Structure](#Structure)
 - [Installation](#Installation)
-    - [Developement](#Development)
+    - [Development](#Development)
         - [Prerequisites](#Prerequisites)
         - [Start](#Start)
         - [Tests](#Tests)

--- a/src/enrich/lib/csv.js
+++ b/src/enrich/lib/csv.js
@@ -101,7 +101,7 @@ function enrichArray(data, response) {
 
   response.forEach((el) => {
     if (el.doi) {
-      results.set(el.doi, el);
+      results.set(el.doi.toLowerCase(), el);
     }
   });
 
@@ -109,7 +109,7 @@ function enrichArray(data, response) {
     if (!el.doi) {
       return;
     }
-    let res = results.get(el.doi);
+    let res = results.get(el.doi.toLowerCase());
     if (!res) {
       return;
     }

--- a/src/enrich/lib/json.js
+++ b/src/enrich/lib/json.js
@@ -79,7 +79,7 @@ function enrichArray(data, response) {
 
   response.forEach((el) => {
     if (el.doi) {
-      results.set(el.doi, el);
+      results.set(el.doi.toLowerCase(), el);
     }
   });
 
@@ -87,7 +87,7 @@ function enrichArray(data, response) {
     if (!el.doi) {
       return;
     }
-    const res = results.get(el.doi);
+    const res = results.get(el.doi.toLowerCase());
     if (!res) {
       return;
     }

--- a/src/frontend/components/enrich/EnrichCard.vue
+++ b/src/frontend/components/enrich/EnrichCard.vue
@@ -63,6 +63,7 @@
             <v-btn
               prepend-icon="mdi-chevron-left"
               variant="tonal"
+              :disabled="isProcessing"
               @click="setStep(2)"
             >
               {{ t("enrich.settings") }}


### PR DESCRIPTION
The comparison between the DOIs of a file to be enriched and the DOIs obtained by the graphql query is not insensitive